### PR TITLE
Simplify AccountService user retrieval by removing unnecessary reposi…

### DIFF
--- a/src/main/java/com/modernbank/account_service/rest/service/impl/AccountServiceImpl.java
+++ b/src/main/java/com/modernbank/account_service/rest/service/impl/AccountServiceImpl.java
@@ -136,8 +136,7 @@ public class AccountServiceImpl implements AccountService {
         Account account = accountRepository.findAccountByIban(iban)
                 .orElseThrow(() -> new NotFoundException(ACCOUNT_NOT_FOUND));
 
-        User user = userRepository.findByTCKN(account.getUser().getTckn())
-                .orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+        User user = account.getUser();
 
         return GetAccountOwnerNameResponse.builder()
                 .firstName(user.getFirstName())


### PR DESCRIPTION
This pull request simplifies the process of retrieving the account owner's user information in the `getAccountOwnerName` method by removing an unnecessary database lookup. Instead of querying the `userRepository` again, it now directly uses the `User` object already associated with the `Account`.

Code simplification:

* Updated `getAccountOwnerName` in `AccountServiceImpl.java` to use the `User` object from the `Account` entity directly, eliminating a redundant repository call.…tory call.