### PR TITLE
Update deploy workflow to rename CI/CD pipeline

### DIFF
--- a/.github/workflows/deploy-account-service.yaml
+++ b/.github/workflows/deploy-account-service.yaml
@@ -1,10 +1,11 @@
-name: Authentication Service CI/CD
+name: Account Service CI/CD
 
 on:
   push:
-    branches: [ "main" ] 
+    branches: [ "master" ]
     paths:
       - 'account-service/**' # Sadece bu klasör değiştiyse tetikle
+  workflow_dispatch:
 
 env:
   # Kendi Azure kaynakların


### PR DESCRIPTION
Update deploy workflow to rename CI/CD pipeline, enable manual triggers, and switch branch to `master`