### PR TITLE
Enable custom security configuration and reintroduce default security…

### DIFF
--- a/src/main/java/com/modernbank/account_service/AccountServiceApplication.java
+++ b/src/main/java/com/modernbank/account_service/AccountServiceApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfi
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
+@SpringBootApplication
 @EnableFeignClients
 @EnableScheduling
 public class AccountServiceApplication {

--- a/src/main/java/com/modernbank/account_service/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/modernbank/account_service/configuration/SecurityConfiguration.java
@@ -3,13 +3,35 @@ package com.modernbank.account_service.configuration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@EnableWebSecurity
 public class SecurityConfiguration {
 
     @Value("${security.encryption.secret-key}")
     private String secretKey;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                // CSRF genelde mikroservislerde ve API'lerde kapatılır
+                .csrf(csrf -> csrf.disable())
+
+                .authorizeHttpRequests(auth -> auth
+                        // Actuator endpointlerine (Prometheus dahil) herkes erişebilsin
+                        .requestMatchers("/actuator/**").permitAll()
+
+                        // Diğer tüm isteklere de izin ver (Çünkü güvenliği Gateway'de yapıyorsun)
+                        // Eğer bu serviste özel güvenlik istiyorsan burayı değiştirebilirsin.
+                        .anyRequest().permitAll()
+                );
+
+        return http.build();
+    }
 
     @Bean
     public Pbkdf2PasswordEncoder passwordEncoder() {


### PR DESCRIPTION
… auto-configuration

- Added `SecurityFilterChain` bean with basic permit-all rules and CSRF disabled, preparing for future fine-tuning.
- Reintroduced default security auto-configuration by removing exclusion from `@SpringBootApplication`.