### PR TITLE
Add cascading delete for user accounts in `deleteUser`

### DIFF
--- a/src/main/java/com/modernbank/account_service/entity/User.java
+++ b/src/main/java/com/modernbank/account_service/entity/User.java
@@ -71,7 +71,7 @@ public class User implements UserDetails {
     @Enumerated(EnumType.STRING)
     private Set<Role> authorities;
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonManagedReference
     private List<Account> accounts;
 

--- a/src/main/java/com/modernbank/account_service/repository/AccountRepository.java
+++ b/src/main/java/com/modernbank/account_service/repository/AccountRepository.java
@@ -22,4 +22,7 @@ public interface AccountRepository extends JpaRepository<Account, String> {
 
     @Query("SELECT a FROM Account a WHERE a.id = ?1")
     Optional<Account> findAccountById(String accountId);
+
+    @Query("DELETE FROM Account a WHERE a.user.id = ?1")
+    void deleteAccountsByUserId(String userId);
 }

--- a/src/main/java/com/modernbank/account_service/rest/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/modernbank/account_service/rest/service/impl/UserServiceImpl.java
@@ -9,6 +9,7 @@ import com.modernbank.account_service.model.GetUserModel;
 import com.modernbank.account_service.model.SavedAccountModel;
 import com.modernbank.account_service.model.UserDetailsModel;
 import com.modernbank.account_service.model.enums.Role;
+import com.modernbank.account_service.repository.AccountRepository;
 import com.modernbank.account_service.repository.SavedAccountRepository;
 import com.modernbank.account_service.repository.UserRepository;
 import com.modernbank.account_service.rest.service.MapperService;
@@ -34,6 +35,8 @@ import static com.modernbank.account_service.constants.ErrorCodeConstants.*;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+
+    private final AccountRepository accountRepository;
 
     private final Pbkdf2PasswordEncoder passwordEncoder;
 
@@ -207,9 +210,11 @@ public class UserServiceImpl implements UserService {
     @Override
     public void deleteUser(AdminDeleteUserRequest request) {
         log.info("Deleting user: userId={}", request.getUserId());
+
         User user = userRepository.findByUserId(request.getUserId())
                 .orElseThrow(() -> new NotFoundException("User not found with userId: " + request.getUserId())); // TODO: Burada ki gibi dynamic value olanlari baska bir sekilde handle edeyim.
 
+        accountRepository.deleteAccountsByUserId(user.getId());
         userRepository.delete(user);
     }
 


### PR DESCRIPTION
- Updated `User` entity with cascading `REMOVE` and `orphanRemoval` for `accounts` relationship.
- Modified `deleteUser` method in `UserServiceImpl` to remove user-related accounts using `AccountRepository`.
- Added `deleteAccountsByUserId` query in `AccountRepository`.