### PR TITLE
HOTFIX account update timestamp in `updateAccountLimit`

### DIFF
--- a/src/main/java/com/modernbank/account_service/rest/service/impl/AccountServiceImpl.java
+++ b/src/main/java/com/modernbank/account_service/rest/service/impl/AccountServiceImpl.java
@@ -240,6 +240,9 @@ public class AccountServiceImpl implements AccountService {
                 log.warn("Invalid category provided for account limit update: {}", category);
                 throw new IllegalArgumentException("Invalid category: " + category);
         }
+
+        account.setUpdatedDate(LocalDateTime.now());
+        accountRepository.save(account);
     }
 
     @Override


### PR DESCRIPTION
- Updated `AccountServiceImpl` to set the `updatedDate` field and save the account during the limit update process.